### PR TITLE
Carriage return removal in Javascript engine fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  version 2.18.0
+  version 2.18.1
 </p>
 
 <br />

--- a/debug_with_inmem.sh
+++ b/debug_with_inmem.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-APP_VERSION="2.18.0"
+APP_VERSION="2.18.1"
 
 mvn spring-boot:run -Dspring-boot.run.jvmArguments="-Dapp.version=$APP_VERSION -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8008"

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.smockin</groupId>
     <artifactId>smockin</artifactId>
-    <version>2.18.0</version>
+    <version>2.18.1</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ fi
 
 
 APP_NAME="sMockin!"
-APP_VERSION="2.18.0"
+APP_VERSION="2.18.1"
 
 APP_DIR_PATH="${HOME}/.smockin"
 DB_DIR_PATH="${APP_DIR_PATH}/db"

--- a/src/main/java/com/smockin/mockserver/service/JavaScriptResponseHandlerImpl.java
+++ b/src/main/java/com/smockin/mockserver/service/JavaScriptResponseHandlerImpl.java
@@ -42,6 +42,7 @@ public class JavaScriptResponseHandlerImpl implements JavaScriptResponseHandler 
     @Autowired
     private UserKeyValueDataService userKeyValueDataService;
 
+    private final static String CARRIAGE_RETURN_REGEX = "\\r\\n|\\r|\\n";
     private final String extensionsDir = "js-extensions/";
 
     public RestfulResponseDTO executeUserResponse(final Request req, final RestfulMock mock) {
@@ -334,12 +335,9 @@ public class JavaScriptResponseHandlerImpl implements JavaScriptResponseHandler 
 
     }
 
-    private String removeLineBreaks(final String input) {
+    String removeLineBreaks(final String input) {
 
-        final String systemCarriage = System.getProperty("line.separator");
-        final String carriage = "\\r\\n|\\r|\\n";
-
-        return StringUtils.replaceAll(input, (systemCarriage != null) ? systemCarriage : carriage, "");
+        return StringUtils.replaceAll(input, CARRIAGE_RETURN_REGEX, "");
     }
 
 }

--- a/src/test/java/com/smockin/mockserver/service/JavaScriptResponseHandlerTest.java
+++ b/src/test/java/com/smockin/mockserver/service/JavaScriptResponseHandlerTest.java
@@ -640,4 +640,32 @@ public class JavaScriptResponseHandlerTest {
 
     }
 
+    @Test
+    public void removeLineBreaks_windows_Test() {
+
+        // Setup
+        final String input = "Hello\r\nWorld";
+
+        // Test
+        final String result = javaScriptResponseHandler.removeLineBreaks(input);
+
+        // Assertions
+        Assert.assertNotNull(result);
+        Assert.assertEquals("HelloWorld", result);
+    }
+
+    @Test
+    public void removeLineBreaks_linux_Test() {
+
+        // Setup
+        final String input = "Hello\nWorld";
+
+        // Test
+        final String result = javaScriptResponseHandler.removeLineBreaks(input);
+
+        // Assertions
+        Assert.assertNotNull(result);
+        Assert.assertEquals("HelloWorld", result);
+    }
+
 }

--- a/start.bat
+++ b/start.bat
@@ -6,7 +6,7 @@ REM   echo %jver%
 IF DEFINED %SMOCKIN_DIR_PATH% (set APP_DIR_PATH=%SMOCKIN_DIR_PATH%) ELSE (set APP_DIR_PATH=%userprofile%\.smockin)
 
 set APP_NAME=sMockin
-set APP_VERSION=2.18.0
+set APP_VERSION=2.18.1
 
 
 set DB_DIR_PATH=%APP_DIR_PATH%\db


### PR DESCRIPTION
Added small fix so that carriage removal in Javascript engine caters for requests coming from either windows or linux based clients.